### PR TITLE
Fix removeNull for empty strings

### DIFF
--- a/hsperfdata.go
+++ b/hsperfdata.go
@@ -218,7 +218,7 @@ func DataPathsByProcessName(processName string) (map[string]string, error) {
 
 // removeNull remove trailing '\x00' byte of s
 func removeNull(s []byte) []byte {
-	if i := bytes.IndexByte(s, '\x00'); i > 0 {
+	if i := bytes.IndexByte(s, '\x00'); i >= 0 {
 		return s[:i]
 	}
 	return s


### PR DESCRIPTION
In C's world, '\x00' stands for the ending symbol of a string thus the empty string is stored as '\x00'. 
In such cases, the original `removeNull` returns an incorrect string in go.