### PR TITLE
refactor: add ParsePerfDataFromBytes

### DIFF
--- a/hsperfdata.go
+++ b/hsperfdata.go
@@ -248,6 +248,16 @@ func ReadPerfData(filepath string, parserTime bool) (map[string]interface{}, err
 			return nil, err
 		}
 	}
+
+	return ParsePerfDataFromBytes(data, parserTime)
+}
+
+// ParsePerfDataFromBytes parser hotspot performance data, and return a map represented entries' name and value,
+// "ticks" are the unit of measurement of time in the Hotspot JVM.
+// when the parserTime is true, tick time value will be parsered to a normal nanoseconds using
+// the "sun.os.hrt.frequency" key in the hsperfdata.
+func ParsePerfDataFromBytes(data []byte, parserTime bool) (map[string]interface{}, error) {
+	var err error
 	buffer := bytes.NewReader(data)
 
 	header := perfdataHeader{}
@@ -337,4 +347,3 @@ func ReadPerfData(filepath string, parserTime bool) (map[string]interface{}, err
 	}
 	return entryMap, nil
 }
-


### PR DESCRIPTION
I have obtained the PrefData bytes through other means.
But there is now only a ReadPerfData func which reads data bytes from file.

I add a new func named ParsePerfDataFromBytes which parse PrefData directly from bytes.